### PR TITLE
fix contention on creating a lock

### DIFF
--- a/locker.go
+++ b/locker.go
@@ -82,6 +82,9 @@ func (lker *Locker) newLock(key string) *sync.RWMutex {
 	lker.locksRW.Lock()
 	defer lker.locksRW.Unlock()
 
+	if lk, ok := lker.locks[key]; ok {
+		return lk
+	}
 	lk := new(sync.RWMutex)
 	lker.locks[key] = lk
 	return lk


### PR DESCRIPTION
When `newLock` is called before the previous one has finished it would duplicate it and fail on releasing.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>